### PR TITLE
Removed a note that was causing confusion.

### DIFF
--- a/articles/connection-cds.md
+++ b/articles/connection-cds.md
@@ -106,8 +106,5 @@ You can leverage the **update a record** command to provide upsert actions, whic
 
 If you have a trigger registered on the update of a record, the flow runs for every *committed* update to the given record. The service invokes your flow asynchronously, and with the payload that it captures at the time the invocation occurs.
 
-> [!NOTE]
-> If you have two updates that happen within seconds of each other, then the flow may be triggered more than once with the latest versioned content.
-
 Flow runs may be delayed if there is a backlog of system jobs in your environment.  If this delay occurs, your flow is triggered when the system job to invoke the flow runs.
 


### PR DESCRIPTION
The note said:

If you have two updates that happen within seconds of each other, then the flow may be triggered more than once with the latest versioned content.

This implies that if each individual action may not trigger a flow. 
I believe this was written to contrast with the polling behavior of the Dynamics 365 connector.