### PR TITLE
the description of "column" is "row"

### DIFF
--- a/articles/desktop-flows/actions-reference/excel.md
+++ b/articles/desktop-flows/actions-reference/excel.md
@@ -552,7 +552,7 @@ Retrieves the first free column and/or row of the active worksheet. This is usef
 |Argument|Type|Description|
 |-----|-----|-----|
 |FirstFreeColumn|Numeric value|The numeric value of the first fully empty column. For example, if column F is the first empty column, it will be stored as '6'|
-|FirstFreeRow|Numeric value|The numeric value of the first fully empty column. For example, if column F is the first empty column, it will be stored as '6'|
+|FirstFreeRow|Numeric value|The numeric value of the first fully empty row. For example, if row 7 is the first empty row, it will be stored as '7'|
 
 
 ##### <a name="getfirstfreecolumnrow_onerror"></a> Exceptions


### PR DESCRIPTION
In "Get first free column/row from Excel worksheet", the description of "column" is "row", so I send a request for correction.