### PR TITLE
remove windows account requirement

### DIFF
--- a/articles/desktop-flows/run-pad-flow.md
+++ b/articles/desktop-flows/run-pad-flow.md
@@ -27,7 +27,7 @@ After you've created and tested a desktop flow, you can run it from an event, sc
 - A work or school account. 
 
    >[!IMPORTANT]
-   >You must use the same work or school account to set up the gateway, to sign into Power Automate, and to log into your Windows device.
+   >You must use the same work or school account to set up the gateway and to sign into Power Automate.
    
 
 ## Run desktop flows unattended or attended


### PR DESCRIPTION
Removed part of the important note as it was misleading: Users can use a completely different account to login to their windows device, they only need to provide these credentials when creation the gateway connection. 