### PR TITLE
Update sequential-modern-approvals.md

### DIFF
--- a/articles/sequential-modern-approvals.md
+++ b/articles/sequential-modern-approvals.md
@@ -62,8 +62,6 @@ The SharePoint Online list you create must include the following columns:
 
 | Title                   | Single line of text    |
 |-------------------------|------------------------|
-| Modified                | Date and time          |
-| Created                 | Date and time          |
 | Vacation start date     | Date and time          |
 | Vacation end date       | Date and time          |
 | Comments                | Single line Of text    |


### PR DESCRIPTION
In the prerequisites section, the columns modified and created were listed in the table twice; once at the top and again lower down in the table. I took the ones from the top of the table out.