### PR TITLE
Use Power Automate flow create process instead of classic

### DIFF
--- a/articles/create-business-process-flow.md
+++ b/articles/create-business-process-flow.md
@@ -2,7 +2,7 @@
 title: "Create a business process flow in Power Apps | MicrosoftDocs"
 description: "Learn how to create a business process flow"
 ms.custom: ""
-ms.date: 09/10/2021
+ms.date: 04/26/2022
 ms.reviewer: "msftman"
 
 ms.suite: ""
@@ -46,14 +46,14 @@ You need a [per user plan](https://flow.microsoft.com/pricing/) in order to crea
 ## Create a business process flow  
   
 1. In Power Automate, select **My flows** from the navigation bar on the left.
-3. Select **Business process flows**
-4. Select **New** tab
-   a. Enter your Flow Name 
-   b. System flow name will be automatically generated.
-   c. Choose a Table the flow will be used in.
-   d. Select **Create** button
+3. Select **Business process flows**.
+4. Select **New**.
+   a. Give your flow a name. 
+   b. Optionally, change the **Name** if you don't want to use the name that the system generates.
+   c. Select the table in which the flow will be used.
+   d. Select **Create**.
   
-     The new process flow is created.  You can now edit it with a first single stage created for you.  
+     The new business process flow is created.  You can now edit it with a first single stage created for you.  
      ![Business process flow window showing main elements.](media/business-process-flow-window-showing-main-elements.png "Business process flow window showing main elements")  
 1. **Add stages.** If your users will progress from one business stage to another in the  process:
   

--- a/articles/create-business-process-flow.md
+++ b/articles/create-business-process-flow.md
@@ -45,23 +45,15 @@ You need a [per user plan](https://flow.microsoft.com/pricing/) in order to crea
 
 ## Create a business process flow  
   
-1. Open [solution explorer](/powerapps/maker/model-driven-apps/advanced-navigation#solution-explorer).
-1. On the left navigation pane, select **Processes**. 
-1. On the **Actions** toolbar, select **New**.  
-1. In the **Create Process**  dialog box, complete the required columns:  
+1. In Power Automate, select **My flows** from the navigation bar on the left.
+3. Select **Business process flows**
+4. Select **New** tab
+   a. Enter your Flow Name 
+   b. System flow name will be automatically generated.
+   c. Choose a Table the flow will be used in.
+   d. Select **Create** button
   
-    - Enter a process name. The name of the process doesn’t need to be unique, but it should be meaningful for people who need to choose a process. You can change this later.  
-  
-    - In the **Category** list, select **Business Process Flow**.  
-  
-         You cannot change the category after you create the process.  
-  
-    - In the **Table** list, select the table on which you want to base the process.  
-  
-         The table you select affects the columns available for steps that can be added to the first stage of the process flow. If you don’t find the table you want, make sure the table has the business process flows (columns will be created) choice in the table definition. You cannot change this after you save the process.  
-1. Select **OK**.  
-  
-     The new process is created, and the business process flow designer opens with a single stage created for you.  
+     The new process flow is created.  You can now edit it with a first single stage created for you.  
      ![Business process flow window showing main elements.](media/business-process-flow-window-showing-main-elements.png "Business process flow window showing main elements")  
 1. **Add stages.** If your users will progress from one business stage to another in the  process:
   


### PR DESCRIPTION
The existing documentation instructs the maker to use the older classic designer to create flows. I have removed this and replaced with instructions on how to use the modern Power Automate create flow page.