### PR TITLE
Add PowerPlatform Api for Desktop flow runtime

### DIFF
--- a/articles/ip-address-configuration.md
+++ b/articles/ip-address-configuration.md
@@ -102,6 +102,7 @@ The following table lists endpoint data requirements for connectivity from a use
 | \*.servicebus.windows.net | https | Listens on Service Bus Relay over TCP.<br>Needed for machine connectivity. |
 |\*.gateway.prod.island.powerapps.com | https | Needed for machine connectivity. |
 | emea.events.data.microsoft.com|https| Handles telemetry for EMEA users.|
+| *.api.powerplatform.com | https | Access to several Power Platform APIs. |
 
 ### U.S. Government endpoints
 
@@ -111,6 +112,9 @@ The following table lists endpoint data requirements for connectivity from a use
 | *.servicebus.usgovcloudapi.net | https | Listens on Service Bus Relay for US government cloud.<br>Needed for machine connectivity. |
 | gateway.gov.island.powerapps.us | https | Needed for machine connectivity for US government cloud (GCC and GCCH). |
 |tb.events.data.microsoft.com|https|Handles telemetry for U.S. government users.|
+| *.api.gov.powerplatform.microsoft.us | https | Access to several Power Platform APIs (U.S. Government - GCC only). |
+| *.api.high.powerplatform.microsoft.us | https | Access to several Power Platform APIs (U.S. Government - GCC High only). |
+| *.api.appsplatform.us | https | Access to several Power Platform APIs (U.S. Government - DoD only). |
 
 ### 21Vinaet endpoints (China)
 
@@ -118,5 +122,6 @@ The following table lists endpoint data requirements for connectivity from a use
 | ------- |  -------- | ---- |
 |crl.digicert.cn<br>ocsp.digicert.cn | http | Access to the CRL servers for 21Vianet operated cloud.<br>Needed when connecting through the on-premises data gateway.|
 |apac.events.data.microsoft.com|https|Handles telemetry for users in China.|
+| *.api.powerplatform.partner.microsoftonline.cn | https | Access to several Power Platform APIs (21Vinaet - China only). |
 
 [!INCLUDE[footer-include](includes/footer-banner.md)]


### PR DESCRIPTION
Desktop flow can ran on dedicated machine not meant to use power automate as such the configuration should not be cumulative, but powerplatform api are used by both, so adding them in Desktop flow runtime too.