### PR TITLE
Example for mutli-line tables was not updated in commit 1bcbf05

### DIFF
--- a/articles/approvals-markdown-support.md
+++ b/articles/approvals-markdown-support.md
@@ -203,7 +203,7 @@ Organize structured data with tables.
 | Heading 1 | Heading 2 | Heading 3 |  
 |-----------|-----------|-----------|  
 | Cell A1 | Cell A2 | Cell A3 |  
-| Cell B1 | Cell B2 | Cell B3<br>second line of text |  
+| Cell B1 | Cell B2 | Cell B3 |  
 
  
 ## Emphasis (bold, italics, strikethrough)  


### PR DESCRIPTION
The example included for split-line tables in commit [1bcbf05](https://github.com/MicrosoftDocs/power-automate-docs/commit/6ee221096e90a775d84d1500a810a431e5909ba4) was not updated.