### PR TITLE
Rename PAD.Java.Installer.exe to PAD.Java.Installer.Host.exe

### DIFF
--- a/articles/desktop-flows/how-to/java.md
+++ b/articles/desktop-flows/how-to/java.md
@@ -28,7 +28,7 @@ The following sections include information for enabling the UI automation in Jav
 
 In order to automate Java applications, particular settings must be in place. 
 
-To install the Java configuration manually, after Power Automate for desktop has been installed, navigate to the installation folder (**C:\Program Files (x86)\Power Automate Desktop**) and run the **PAD.Java.Installer.exe** as an administrator. 
+To install the Java configuration manually, after Power Automate for desktop has been installed, navigate to the installation folder (**C:\Program Files (x86)\Power Automate Desktop**) and run the **PAD.Java.Installer.Host.exe** as an administrator. 
 
 Logs for Java automation with Power Automate for desktop can be found in the **%temp%/ java_automation_log** folder (for example, **C:\Users\username\AppData\Local\Temp\java_automation_log**). 
 


### PR DESCRIPTION
Updated the installer file name to improve naming consistency across the project.


