### PR TITLE
Edit automation-coe-strategy.md: fix typo

### DIFF
--- a/articles/guidance/automation-kit/overview/automation-coe-strategy.md
+++ b/articles/guidance/automation-kit/overview/automation-coe-strategy.md
@@ -99,7 +99,7 @@ The Automation Kit and components of the CoE Starter Kit, including the ALM Acce
 
 #### ALM components
 
-- **Code Review**: Reviews for solutions in Azure DevOps with the ALM Accelerator. The ALM Accelerator Azure DevOp extensions allow the solution to be unpacked and the script definition from the exported solution versions to be compared for changes side by side.
+- **Code Review**: Reviews for solutions in Azure DevOps with the ALM Accelerator. The ALM Accelerator Azure DevOps extensions allow the solution to be unpacked and the script definition from the exported solution versions to be compared for changes side by side.
 - **Monitoring**: The Automation Kit provides a near real-time tracking process to measure the impact of deployed solutions.
 - **Data Loss Prevention**: Determine the impact of DLP rules on deployed desktop flows using the Automation Kit.
 - **Dashboard and Data ETL**: Synchronize data from multiple environments to a centralized dashboard to monitor the impact of deployed solutions.


### PR DESCRIPTION
Searching for "Azure DevOp extension" yields 1 result.

https://learn.microsoft.com/en-us/search/?terms=%22Azure%20DevOp%20extensions%22

Searching for "Azure DevOps extension" yields 2532 results.

https://learn.microsoft.com/en-us/search/?terms=%22Azure%20DevOps%20extensions%22

This commit changes the use of "Azure DevOp extension" to "Azure DevOps extension" to make the one use consistent with the rest.