### PR TITLE
Edit automation-coe-strategy.md

### DIFF
--- a/articles/guidance/automation-kit/overview/automation-coe-strategy.md
+++ b/articles/guidance/automation-kit/overview/automation-coe-strategy.md
@@ -112,7 +112,7 @@ The Automation Kit and the ALM Accelerator can be combined to help customers gro
 
 ![Automation Maturity Model - Mapping to Automation Kit and ALM Accelerator](../media/automation-matutity-model.png)
 
-The dotted blue boxes indicate the maturity model areas that the Automation Kit addresses using the [Holistic enterprise automation techniques (HEAT)](/power-platform/guidance/automation-coe/heat). Dotted green boxes indicate areas address by the ALM Accelerator.
+The dotted blue boxes indicate the maturity model areas that the Automation Kit addresses using the [Holistic enterprise automation techniques (HEAT)](/power-platform/guidance/automation-coe/heat). Dotted green boxes indicate areas the ALM Accelerator addresses.
 
 ### Empower
 


### PR DESCRIPTION
```
Dotted green boxes indicate areas address by the ALM Accelerator.
```

To keep passive voice ("address by the ALM Accelerator") and make grammatical could replace `address` with `addressed`.

Instead, replace passive voice with active voice ('the ALM Accelerator addresses'). The sentence before the one I edit uses active voice ("The dotted blue boxes indicate the maturity model areas that the Automation Kit addresses"). This edit makes the voice consistent between the two.