### PR TITLE
Actionable Approval mails in Outlook are not supported for Guest user…

### DIFF
--- a/articles/share-guest-users.md
+++ b/articles/share-guest-users.md
@@ -42,7 +42,7 @@ If a guest user needs to only run a flow, they need to have the **Sharing-Run On
 
 ### Approvals
 
-A guest user can be assigned an approval, receive an approval email, and be routed to the **Approvals** page in the guest tenant to approve or reject. They can also view and interact with the approval email body in the same way as a nonguest user.
+A guest user can be assigned an approval, receive an approval email, and be routed to the **Approvals** page in the guest tenant to approve or reject.
 
 Guest users can't see the approvals from their guest tenant while they're in their original tenant, or from their original tenant while they're in their guest tenant.  
 


### PR DESCRIPTION
As mentioned in this official document https://learn.microsoft.com/en-us/connectors/approvals/#known-issues-and-limitations Actionable Approval mails in Outlook are not supported for Guest users in a tenant. Guest users will need to go to the Power Automate portal to act on an approval.
 
The sentence should be removed as it's causing confusion and misunderstanding.